### PR TITLE
Fixed typo in progress ring page

### DIFF
--- a/src/content/components/progress-ring.mdx
+++ b/src/content/components/progress-ring.mdx
@@ -14,7 +14,7 @@ import BasicExample from "@components/examples/progress-ring/BasicExample.astro"
   <BasicExample />
   <Fragment slot="html">
     ```html
-    <vscode-progress-link></vscode-progress-link>
+    <vscode-progress-ring></vscode-progress-ring>
     ```
   </Fragment>
 </Demo>


### PR DESCRIPTION
Changed docs to use <vscode-progress-ring> instead of <vscode-progress-link>