### PR TITLE
Elaborate on link tag id prop for vscode-icon

### DIFF
--- a/src/content/components/icon.mdx
+++ b/src/content/components/icon.mdx
@@ -18,6 +18,11 @@ import Imports from "@components/examples/icon/Imports.astro";
   ```html
   <!--
     Download codicons from https://github.com/microsoft/vscode-codicons
+
+    Note the required `id` on the link element!
+    To use web fonts in web components, the component needs to include
+    the font stylesheet in addition to the page. This id serves as a lookup so
+    the icon component can automatically create and insert it's own link tag.
   -->
   <link
     rel="stylesheet"


### PR DESCRIPTION
I was banging my head against the wall for a couple of hours yesterday as I couldn't make icons to show up in my extension. My initial thought was an error in the way assets are bundled and resolved or some misconfigured CSPs but it was much simpler. Had i _just_ copied the line from the icon documentation it probably would have worked out of the box. 

Long story short, I was missing the `id` on the link tag. So after reading the implementation I understood what it's used for and why it's needed. I also found that there were at least 2 occurrences of the same issue (https://github.com/vscode-elements/elements/issues/15 and https://github.com/vscode-elements/elements/issues/125).

Let me know if you think stating the necessity a bit more explicitly and elaborating in the docs makes sense (it certainly would have helped me not overlooking this).
I'm also open for addressing this in a different way (like an `Infobox` or similar).
