### PR TITLE
Explicitly set npmjs.org as the registry

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+# Prevent accidental package upgrades from a private registry and avoid writing private URLs to the lock file.
+registry="https://registry.npmjs.org/"


### PR DESCRIPTION
Prevent accidental package upgrades from a private registry and avoid writing private URLs to the lock file.